### PR TITLE
add a script to update the umm-v related urls

### DIFF
--- a/.github/workflows/umm_v_update_related_url.yml
+++ b/.github/workflows/umm_v_update_related_url.yml
@@ -1,0 +1,122 @@
+# Update or delete a UMM-V variable RelatedURLs entry
+name: UMM-V Update Related URL
+
+on:
+  workflow_dispatch:
+    inputs:
+      collection_name:
+        description: "Collection short name"
+        required: true
+        type: string
+      provider:
+        description: "CMR provider"
+        required: true
+        default: "POCLOUD"
+        type: string
+      variable_name:
+        description: "UMM-V variable name"
+        required: true
+        type: string
+      env:
+        description: "Target CMR environment"
+        required: true
+        default: "uat"
+        type: choice
+        options:
+          - uat
+          - ops
+      action:
+        description: "Related URL action"
+        required: true
+        default: "add"
+        type: choice
+        options:
+          - add
+          - delete
+      url:
+        description: "URL to add or delete from RelatedURLs"
+        required: true
+        type: string
+
+jobs:
+  build:
+    name: Build, Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Poetry
+        uses: abatilo/actions-poetry@v4
+        with:
+          poetry-version: 2.3.2
+
+      - name: Poetry Steps
+        run: poetry install
+
+      - name: Get Launchpad Tokens
+        id: launchpad_token_generator
+        run: |
+          PAYLOAD=$(echo '{"client_id": "UmmVRelatedUrlGithubAction", "minimum_alive_secs": 3300}' | base64)
+
+          aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID_CUMULUS_UAT }}
+          aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY_CUMULUS_UAT }}
+          aws configure set region us-west-2
+
+          OUTPUT_FILE_UAT=result_uat.json
+          aws lambda invoke \
+            --function-name uat-launchpad_token_dispenser \
+            --payload "$PAYLOAD" \
+            "$OUTPUT_FILE_UAT" > /dev/null 2>&1
+
+          if jq -e 'has("errorMessage")' "$OUTPUT_FILE_UAT" > /dev/null; then
+            echo "Error detected in UAT Launchpad Lambda response:"
+            cat "$OUTPUT_FILE_UAT"
+            exit 1
+          fi
+
+          UAT_TOKEN=$(jq -r '.sm_token' < "$OUTPUT_FILE_UAT")
+          echo "::add-mask::$UAT_TOKEN"
+          echo "uat_launchpad_token=$UAT_TOKEN" >> "$GITHUB_OUTPUT"
+
+          aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID_CUMULUS_OPS }}
+          aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY_CUMULUS_OPS }}
+
+          OUTPUT_FILE_OPS=result_ops.json
+          aws lambda invoke \
+            --function-name ops-launchpad_token_dispenser \
+            --payload "$PAYLOAD" \
+            "$OUTPUT_FILE_OPS" > /dev/null 2>&1
+
+          if jq -e 'has("errorMessage")' "$OUTPUT_FILE_OPS" > /dev/null; then
+            echo "Error detected in OPS Launchpad Lambda response:"
+            cat "$OUTPUT_FILE_OPS"
+            exit 1
+          fi
+
+          OPS_TOKEN=$(jq -r '.sm_token' < "$OUTPUT_FILE_OPS")
+          echo "::add-mask::$OPS_TOKEN"
+          echo "ops_launchpad_token=$OPS_TOKEN" >> "$GITHUB_OUTPUT"
+
+      - name: Update or Delete UMM-V Related URL
+        working-directory: umm_v_auto
+        env:
+          OPS_LAUNCHPAD_TOKEN: ${{ steps.launchpad_token_generator.outputs.ops_launchpad_token }}
+          UAT_LAUNCHPAD_TOKEN: ${{ steps.launchpad_token_generator.outputs.uat_launchpad_token }}
+          LAUNCHPAD_TOKEN: ${{ steps.launchpad_token_generator.outputs.uat_launchpad_token }}
+        run: |
+          if [ "${{ inputs.action }}" = "delete" ]; then
+            ACTION_FLAG="-d"
+          else
+            ACTION_FLAG="-u"
+          fi
+
+          poetry run python umm_v_update_related_url.py \
+            -c "${{ inputs.collection_name }}" \
+            -p "${{ inputs.provider }}" \
+            -v "${{ inputs.variable_name }}" \
+            -e "${{ inputs.env }}" \
+            "$ACTION_FLAG" "${{ inputs.url }}"

--- a/umm_v_auto/README.md
+++ b/umm_v_auto/README.md
@@ -16,9 +16,10 @@ Set the required authentication environment variables before running the script:
 - `OPS_LAUNCHPAD_TOKEN` for `ops`
 - `UAT_LAUNCHPAD_TOKEN` for `uat`
 
-The script uses the Launchpad token for both CMR lookups and the ingest update.
+The script uses Launchpad for both CMR lookups and the ingest update.
+No EDL token is required.
 
-If you prefer to keep using a single Launchpad token, `LAUNCHPAD_TOKEN` still works as a fallback for both environments.
+If you prefer to keep using a single Launchpad token, `LAUNCHPAD_TOKEN` works as a fallback for both environments.
 
 ## Basic Usage
 

--- a/umm_v_auto/README.md
+++ b/umm_v_auto/README.md
@@ -13,10 +13,14 @@ It supports three actions:
 Set the required authentication environment variables before running the script:
 
 - `LAUNCHPAD_TOKEN`
+- `OPS_LAUNCHPAD_TOKEN` for `ops`
+- `UAT_LAUNCHPAD_TOKEN` for `uat`
 - `OPS_EDL_TOKEN` for `ops`
 - `UAT_EDL_TOKEN` for `uat`
 
 The script looks up the collection and variable in CMR, then updates the matching variable record.
+
+If you prefer to keep using a single Launchpad token, `LAUNCHPAD_TOKEN` still works as a fallback for both environments.
 
 ## Basic Usage
 
@@ -33,6 +37,11 @@ Required flags:
 - `-c`, `--collection-name`: collection short name
 - `-v`, `--variable-name`: variable name
 - `-e`, `--env`: target environment, one of `ops` or `uat`
+
+The `-e` flag controls which CMR venue is queried and which Launchpad token is used:
+
+- `ops` uses `OPS_LAUNCHPAD_TOKEN` if it is set, otherwise `LAUNCHPAD_TOKEN`
+- `uat` uses `UAT_LAUNCHPAD_TOKEN` if it is set, otherwise `LAUNCHPAD_TOKEN`
 
 Action flags:
 

--- a/umm_v_auto/README.md
+++ b/umm_v_auto/README.md
@@ -15,10 +15,8 @@ Set the required authentication environment variables before running the script:
 - `LAUNCHPAD_TOKEN`
 - `OPS_LAUNCHPAD_TOKEN` for `ops`
 - `UAT_LAUNCHPAD_TOKEN` for `uat`
-- `OPS_EDL_TOKEN` for `ops`
-- `UAT_EDL_TOKEN` for `uat`
 
-The script looks up the collection and variable in CMR, then updates the matching variable record.
+The script uses the Launchpad token for both CMR lookups and the ingest update.
 
 If you prefer to keep using a single Launchpad token, `LAUNCHPAD_TOKEN` still works as a fallback for both environments.
 
@@ -186,3 +184,18 @@ When adding from a JSON file, duplicate URLs in the file are skipped, and URLs t
 1. Create a JSON file for the new related URL entry if you need custom metadata.
 2. Run the script with `--related-url-file` to add it.
 3. Run the script with `--delete-url` if you need to remove a bad entry.
+
+## GitHub Actions
+
+There is a manual workflow at `.github/workflows/umm_v_update_related_url.yml` for adding or deleting a single URL.
+
+It accepts these dispatch inputs:
+
+- `collection_name`
+- `provider`
+- `variable_name`
+- `env`
+- `action`
+- `url`
+
+Set `action` to `add` or `delete`. The workflow fetches the correct Launchpad token for the selected environment and runs the script with `--new-url` or `--delete-url` accordingly.

--- a/umm_v_auto/README.md
+++ b/umm_v_auto/README.md
@@ -1,1 +1,179 @@
-# umm_v_auto_sync
+# UMM-V Related URL Update
+
+`umm_v_update_related_url.py` updates the `RelatedUrls` list for a UMM-V variable in CMR.
+
+It supports three actions:
+
+- add a basic URL entry
+- add a full RelatedUrls object from a JSON file
+- delete an entry by exact URL match
+
+## Requirements
+
+Set the required authentication environment variables before running the script:
+
+- `LAUNCHPAD_TOKEN`
+- `OPS_EDL_TOKEN` for `ops`
+- `UAT_EDL_TOKEN` for `uat`
+
+The script looks up the collection and variable in CMR, then updates the matching variable record.
+
+## Basic Usage
+
+```bash
+python umm_v_auto/umm_v_update_related_url.py \
+  -c COLLECTION_SHORT_NAME \
+  -v VARIABLE_NAME \
+  -e uat \
+  -u https://example.com/data.bin
+```
+
+Required flags:
+
+- `-c`, `--collection-name`: collection short name
+- `-v`, `--variable-name`: variable name
+- `-e`, `--env`: target environment, one of `ops` or `uat`
+
+Action flags:
+
+- `-u`, `--new-url`: add a simple URL entry
+- `-f`, `--related-url-file`: add a full JSON object from a file
+- `-d`, `--delete-url`: delete an entry by exact URL
+
+You must choose exactly one action flag.
+
+## Add a Simple URL
+
+Use `--new-url` when you only need to attach a URL and do not need custom metadata.
+
+The JSON file approach is the preferred option when you need more than a bare URL. The simple URL path fills in default values for the related-url fields, and those defaults may not be the best fit for your use case.
+
+```bash
+python umm_v_auto/umm_v_update_related_url.py \
+  -c MY_COLLECTION \
+  -v MY_VARIABLE \
+  -e uat \
+  -u https://example.com/data.bin
+```
+
+For simple URL adds, the script builds a default RelatedUrls object with:
+
+- `URL`
+- `URLContentType`
+- `Type`
+- `Subtype`
+- `Format`
+- `MimeType`
+
+## Recommended Way
+
+Use `--related-url-file` whenever possible.
+
+That approach lets you provide the full RelatedUrls object directly, which is better when:
+
+- you need a specific `Type`, `Subtype`, or `URLContentType`
+- you want metadata like `Description`, `Format`, or `MimeType`
+- the default values from `--new-url` are not appropriate
+- you want to add more than one related URL at once
+
+## Add a Full RelatedUrls Object
+
+Use `--related-url-file` when you want to provide the exact object to store in `RelatedUrls`.
+
+Example file, `related_url.json`:
+
+```json
+{
+  "Description": "Colormap that can be used for this variable in GDAL-compatible text format.",
+  "URLContentType": "VisualizationURL",
+  "Type": "Color Map",
+  "Subtype": "Harmony GDAL",
+  "URL": "https://gibs.earthdata.nasa.gov/colormaps/txt/GHRSST_Sea_Surface_Temperature.txt",
+  "Format": "Text File",
+  "MimeType": "text/plain"
+}
+```
+
+Run it like this:
+
+```bash
+python umm_v_auto/umm_v_update_related_url.py \
+  -c MY_COLLECTION \
+  -v MY_VARIABLE \
+  -e uat \
+  -f related_url.json
+```
+
+Rules for the JSON file:
+
+- it may contain a single JSON object or a list of JSON objects
+- every object must include a non-empty `URL` field
+- any other keys are passed through as-is
+
+Example file with multiple entries:
+
+```json
+[
+  {
+    "URL": "https://example.com/one.txt",
+    "URLContentType": "VisualizationURL",
+    "Type": "Color Map"
+  },
+  {
+    "URL": "https://example.com/two.txt",
+    "URLContentType": "VisualizationURL",
+    "Type": "Color Map",
+    "Description": "Second related URL"
+  }
+]
+```
+
+## Delete a URL
+
+Use `--delete-url` to remove entries whose `URL` matches exactly.
+
+```bash
+python umm_v_auto/umm_v_update_related_url.py \
+  -c MY_COLLECTION \
+  -v MY_VARIABLE \
+  -e uat \
+  -d https://example.com/data.bin
+```
+
+Notes on delete behavior:
+
+- matching is exact
+- all entries with that `URL` are removed
+- if no match is found, the script exits without updating CMR
+
+## Uniqueness
+
+RelatedUrls entries need to be unique by `URL`.
+
+If you need to modify an existing entry:
+
+1. delete the existing URL first
+2. add the updated entry again
+
+This is the safest way to ensure the updated metadata is stored cleanly.
+
+When adding from a JSON file, duplicate URLs in the file are skipped, and URLs that already exist in the variable are also skipped.
+
+## Defaults And Lookup Behavior
+
+- `--provider` defaults to `POCLOUD`
+- collection lookup uses the collection short name and provider
+- variable lookup uses the variable name plus the linked collection concept ID
+- if multiple variables match, the script stops and reports the candidate concept IDs
+
+## Operational Notes
+
+- The script deduplicates adds by `URL`
+- The script updates the UMM payload using the variable's existing record and replaces `RelatedUrls`
+- If you are testing in a non-production environment, verify the target `-e` value carefully before running
+
+## Example Workflow
+
+1. Create a JSON file for the new related URL entry if you need custom metadata.
+2. Run the script with `--related-url-file` to add it.
+3. Run the script with `--delete-url` if you need to remove a bad entry.

--- a/umm_v_auto/umm_v_update_related_url.py
+++ b/umm_v_auto/umm_v_update_related_url.py
@@ -89,7 +89,8 @@ def build_new_related_url(new_url: str) -> dict:
         "Type": "Color Map",
         "Subtype":"Harmony GDAL",
         "Format":"Text File",
-        "MimeType":"text/plain"
+        "MimeType":"text/plain",
+        "Description": "Colormap that can be used for this variable in GDAL-compatible text format."
     }
 
 

--- a/umm_v_auto/umm_v_update_related_url.py
+++ b/umm_v_auto/umm_v_update_related_url.py
@@ -20,6 +20,12 @@ EDL_TOKEN_ENV_VARS = {
 }
 
 
+LAUNCHPAD_TOKEN_ENV_VARS = {
+    "ops": "OPS_LAUNCHPAD_TOKEN",
+    "uat": "UAT_LAUNCHPAD_TOKEN",
+}
+
+
 def get_edl_token(env: str) -> str:
     token_env_var = EDL_TOKEN_ENV_VARS.get(env)
     if not token_env_var:
@@ -31,6 +37,27 @@ def get_edl_token(env: str) -> str:
         return edl_token
 
     print(f"ERROR: {token_env_var} environment variable is not set.", file=sys.stderr)
+    sys.exit(1)
+
+
+def get_launchpad_token(env: str) -> str:
+    token_env_var = LAUNCHPAD_TOKEN_ENV_VARS.get(env)
+    if not token_env_var:
+        print(f"ERROR: Unsupported environment '{env}'.", file=sys.stderr)
+        sys.exit(1)
+
+    launchpad_token = os.environ.get(token_env_var)
+    if launchpad_token:
+        return launchpad_token
+
+    fallback_token = os.environ.get("LAUNCHPAD_TOKEN")
+    if fallback_token:
+        return fallback_token
+
+    print(
+        f"ERROR: {token_env_var} environment variable is not set and LAUNCHPAD_TOKEN fallback is not set.",
+        file=sys.stderr,
+    )
     sys.exit(1)
 
 
@@ -191,11 +218,7 @@ def main():
     args = parse_args()
 
     edl_token = get_edl_token(args.env)
-
-    launchpad_token = os.environ.get("LAUNCHPAD_TOKEN")
-    if not launchpad_token:
-        print("ERROR: LAUNCHPAD_TOKEN environment variable is not set.", file=sys.stderr)
-        sys.exit(1)
+    launchpad_token = get_launchpad_token(args.env)
 
     cmr_base = CMR_URLS[args.env]
     provider = args.provider.upper()

--- a/umm_v_auto/umm_v_update_related_url.py
+++ b/umm_v_auto/umm_v_update_related_url.py
@@ -1,0 +1,287 @@
+"""Script to add a new URL to the RelatedURLs field of a UMM-V variable."""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+import requests
+
+
+CMR_URLS = {
+    "ops": "https://cmr.earthdata.nasa.gov",
+    "uat": "https://cmr.uat.earthdata.nasa.gov",
+}
+
+
+EDL_TOKEN_ENV_VARS = {
+    "ops": "OPS_EDL_TOKEN",
+    "uat": "UAT_EDL_TOKEN",
+}
+
+
+def get_edl_token(env: str) -> str:
+    token_env_var = EDL_TOKEN_ENV_VARS.get(env)
+    if not token_env_var:
+        print(f"ERROR: Unsupported environment '{env}'.", file=sys.stderr)
+        sys.exit(1)
+
+    edl_token = os.environ.get(token_env_var)
+    if edl_token:
+        return edl_token
+
+    print(f"ERROR: {token_env_var} environment variable is not set.", file=sys.stderr)
+    sys.exit(1)
+
+
+def get_collection_metadata(cmr_base: str, collection_name: str, provider: str, edl_token: str) -> dict:
+    url = f"{cmr_base}/search/collections.umm_json"
+    headers = {"Authorization": f"Bearer {edl_token}"}
+    params = {"ShortName": collection_name, "provider": provider, "page_size": 1}
+    resp = requests.get(url, headers=headers, params=params)
+    resp.raise_for_status()
+    items = resp.json().get("items", [])
+    if not items:
+        raise ValueError(f"Collection '{collection_name}' not found in CMR ({cmr_base})")
+    if len(items) > 1:
+        print(f"Warning: {len(items)} collections matched '{collection_name}', using the first result.")
+    return items[0]
+
+
+def get_collection_concept_id(collection_record: dict) -> str:
+    return collection_record["meta"]["concept-id"]
+
+
+def get_variable_candidates(cmr_base: str, variable_name: str, collection_concept_id: str, edl_token: str) -> list[dict]:
+    url = f"{cmr_base}/search/variables.json"
+    headers = {"Authorization": f"Bearer {edl_token}"}
+    params = {"name": variable_name, "page_size": 2000}
+    resp = requests.get(url, headers=headers, params=params)
+    resp.raise_for_status()
+    entries = resp.json().get("items", [])
+    return [
+        item
+        for item in entries
+        if collection_concept_id in item.get("associations", {}).get("collections", [])
+    ]
+
+
+def get_variable_record(cmr_base: str, variable_concept_id: str, edl_token: str) -> dict:
+    url = f"{cmr_base}/search/variables.umm_json"
+    headers = {"Authorization": f"Bearer {edl_token}"}
+    params = {"concept-id": variable_concept_id}
+    resp = requests.get(url, headers=headers, params=params)
+    resp.raise_for_status()
+    items = resp.json().get("items", [])
+    if not items:
+        raise ValueError(f"Variable concept ID '{variable_concept_id}' not found in CMR ({cmr_base})")
+    return items[0]
+
+
+def build_new_related_url(new_url: str) -> dict:
+    return {
+        "URL": new_url,
+        "URLContentType": "VisualizationURL",
+        "Type": "Color Map",
+        "Subtype":"Harmony GDAL",
+        "Format":"Text File",
+        "MimeType":"text/plain"
+    }
+
+
+def load_related_url_file(path: str) -> list[dict]:
+    file_path = Path(path)
+    try:
+        with file_path.open("r", encoding="utf-8") as f:
+            payload = json.load(f)
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(f"Related URL file not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Related URL file is not valid JSON: {path}") from exc
+
+    if isinstance(payload, dict):
+        payload = [payload]
+    elif not isinstance(payload, list):
+        raise ValueError("Related URL file must contain either a JSON object or a list of objects.")
+
+    if not payload:
+        raise ValueError("Related URL file must not be empty.")
+
+    for index, entry in enumerate(payload, start=1):
+        if not isinstance(entry, dict):
+            raise ValueError(f"Related URL file entry {index} must be a JSON object.")
+        if not entry.get("URL"):
+            raise ValueError(f"Related URL file entry {index} must include a non-empty 'URL' field.")
+
+    return payload
+
+
+def update_variable(cmr_base: str, collection_concept_id: str, native_id: str, umm: dict, launchpad_token: str) -> dict:
+    url = f"{cmr_base}/ingest/collections/{collection_concept_id}/variables/{native_id}"
+    headers = {
+        "Content-Type": "application/vnd.nasa.cmr.umm+json",
+        "Authorization": launchpad_token,
+        "Accept": "application/json",
+    }
+    resp = requests.put(url, data=json.dumps(umm, allow_nan=False), headers=headers)
+    print(resp.json())
+    resp.raise_for_status()
+    return resp.json()
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Add a new URL to the RelatedURLs of a UMM-V variable.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "-c", "--collection-name",
+        required=True,
+        metavar="COLLECTION_NAME",
+        help="Short name of the collection (e.g. SMAP_RSS_L3_SSS_SMI_8DAY_V4)",
+    )
+    parser.add_argument(
+        "-v", "--variable-name",
+        required=True,
+        metavar="VARIABLE_NAME",
+        help="Name of the UMM-V variable to update",
+    )
+    parser.add_argument(
+        "-u", "--new-url",
+        required=False,
+        metavar="NEW_URL",
+        help="New URL to add to the variable's RelatedURLs",
+    )
+    parser.add_argument(
+        "-f", "--related-url-file",
+        required=False,
+        metavar="FILE",
+        help="Path to a JSON file containing a full RelatedURLs entry to add",
+    )
+    parser.add_argument(
+        "-d", "--delete-url",
+        required=False,
+        metavar="URL",
+        help="Exact URL to remove from the variable's RelatedURLs",
+    )
+    parser.add_argument(
+        "-e", "--env",
+        required=True,
+        choices=["ops", "uat"],
+        help="CMR environment to target",
+    )
+    parser.add_argument(
+        "-p", "--provider",
+        default="POCLOUD",
+        metavar="PROVIDER",
+        help="CMR provider to target for the collection lookup",
+    )
+    args = parser.parse_args()
+
+    action_count = sum(
+        1 for value in [args.new_url, args.related_url_file, args.delete_url] if value
+    )
+    if action_count != 1:
+        parser.error("Specify exactly one of --new-url, --related-url-file, or --delete-url.")
+
+    return args
+
+
+def main():
+    args = parse_args()
+
+    edl_token = get_edl_token(args.env)
+
+    launchpad_token = os.environ.get("LAUNCHPAD_TOKEN")
+    if not launchpad_token:
+        print("ERROR: LAUNCHPAD_TOKEN environment variable is not set.", file=sys.stderr)
+        sys.exit(1)
+
+    cmr_base = CMR_URLS[args.env]
+    provider = args.provider.upper()
+
+    print(f"Looking up collection '{args.collection_name}' for provider '{provider}' in {args.env} ({cmr_base})...")
+    collection_record = get_collection_metadata(cmr_base, args.collection_name, provider, edl_token)
+    collection_concept_id = get_collection_concept_id(collection_record)
+    print(f"Found collection concept ID: {collection_concept_id}")
+
+    print(f"Searching for variable keyword '{args.variable_name}'...")
+    variable_candidates = get_variable_candidates(cmr_base, args.variable_name, collection_concept_id, edl_token)
+    if not variable_candidates:
+        raise ValueError(
+            f"No variable found for keyword '{args.variable_name}' linked to collection '{collection_concept_id}' "
+            f"in CMR ({cmr_base})"
+        )
+
+    if len(variable_candidates) > 1:
+        candidate_ids = ", ".join(item.get("concept_id", "<unknown>") for item in variable_candidates)
+        raise ValueError(
+            f"Multiple variables matched keyword '{args.variable_name}' and collection '{collection_concept_id}'. "
+            f"Candidate variable concept IDs: {candidate_ids}"
+        )
+
+    variable_concept_id = variable_candidates[0]["concept_id"]
+    print(f"Found linked variable concept ID: {variable_concept_id}")
+
+    variable_record = get_variable_record(cmr_base, variable_concept_id, edl_token)
+    meta = variable_record["meta"]
+    umm = variable_record["umm"]
+    native_id = meta["native-id"]
+    concept_id = meta["concept-id"]
+    print(f"Found variable: {concept_id} (native-id: {native_id})")
+
+    existing_urls = umm.get("RelatedURLs", [])
+
+    if args.delete_url:
+        filtered_urls = [entry for entry in existing_urls if entry.get("URL") != args.delete_url]
+        if len(filtered_urls) == len(existing_urls):
+            print(
+                f"URL not found in RelatedURLs for variable '{args.variable_name}'. No update needed."
+            )
+            sys.exit(0)
+        updated_umm = {**umm, "RelatedURLs": filtered_urls}
+        print(f"Updating variable by deleting URL: {args.delete_url}")
+    else:
+        if args.related_url_file:
+            new_entries = load_related_url_file(args.related_url_file)
+        else:
+            new_entries = [build_new_related_url(args.new_url)]
+
+        existing_url_values = {entry.get("URL") for entry in existing_urls}
+        seen_input_urls = set()
+        entries_to_add = []
+
+        for new_entry in new_entries:
+            new_url = new_entry["URL"]
+            if new_url in existing_url_values:
+                print(
+                    f"URL already exists in RelatedURLs for variable '{args.variable_name}': {new_url}. Skipping."
+                )
+                continue
+            if new_url in seen_input_urls:
+                print(f"Duplicate URL in input file skipped: {new_url}")
+                continue
+            seen_input_urls.add(new_url)
+            entries_to_add.append(new_entry)
+
+        if not entries_to_add:
+            print(f"No new URLs to add for variable '{args.variable_name}'. No update needed.")
+            sys.exit(0)
+
+        updated_umm = {**umm, "RelatedURLs": existing_urls + entries_to_add}
+        print(
+            "Updating variable with new URL(s): "
+            + ", ".join(entry["URL"] for entry in entries_to_add)
+        )
+
+    response = update_variable(cmr_base, collection_concept_id, native_id, updated_umm, launchpad_token)
+
+    if "errors" in response:
+        print(f"ERROR: CMR ingest failed:\n\t" + "\n\t".join(response["errors"]), file=sys.stderr)
+        sys.exit(1)
+
+    print(f"SUCCESS: Variable updated. Concept ID: {response.get('concept-id')}")
+
+
+if __name__ == "__main__":
+    main()

--- a/umm_v_auto/umm_v_update_related_url.py
+++ b/umm_v_auto/umm_v_update_related_url.py
@@ -1,4 +1,4 @@
-"""Script to add a new URL to the RelatedURLs field of a UMM-V variable."""
+"""Script to add, update, or delete a RelatedURLs entry for a UMM-V variable."""
 
 import argparse
 import json
@@ -14,30 +14,10 @@ CMR_URLS = {
 }
 
 
-EDL_TOKEN_ENV_VARS = {
-    "ops": "OPS_EDL_TOKEN",
-    "uat": "UAT_EDL_TOKEN",
-}
-
-
 LAUNCHPAD_TOKEN_ENV_VARS = {
     "ops": "OPS_LAUNCHPAD_TOKEN",
     "uat": "UAT_LAUNCHPAD_TOKEN",
 }
-
-
-def get_edl_token(env: str) -> str:
-    token_env_var = EDL_TOKEN_ENV_VARS.get(env)
-    if not token_env_var:
-        print(f"ERROR: Unsupported environment '{env}'.", file=sys.stderr)
-        sys.exit(1)
-
-    edl_token = os.environ.get(token_env_var)
-    if edl_token:
-        return edl_token
-
-    print(f"ERROR: {token_env_var} environment variable is not set.", file=sys.stderr)
-    sys.exit(1)
 
 
 def get_launchpad_token(env: str) -> str:
@@ -54,17 +34,14 @@ def get_launchpad_token(env: str) -> str:
     if fallback_token:
         return fallback_token
 
-    print(
-        f"ERROR: {token_env_var} environment variable is not set and LAUNCHPAD_TOKEN fallback is not set.",
-        file=sys.stderr,
-    )
+    print(f"ERROR: {token_env_var} environment variable is not set and LAUNCHPAD_TOKEN fallback is not set.", file=sys.stderr)
     sys.exit(1)
 
 
-def get_collection_metadata(cmr_base: str, collection_name: str, provider: str, edl_token: str) -> dict:
+def get_collection_metadata(cmr_base: str, collection_name: str, provider: str, launchpad_token: str) -> dict:
     url = f"{cmr_base}/search/collections.umm_json"
-    headers = {"Authorization": f"Bearer {edl_token}"}
-    params = {"ShortName": collection_name, "provider": provider, "page_size": 1}
+    headers = {"Authorization": launchpad_token}
+    params = {"ShortName": collection_name, "provider": provider, "page_size": 2000}
     resp = requests.get(url, headers=headers, params=params)
     resp.raise_for_status()
     items = resp.json().get("items", [])
@@ -79,9 +56,9 @@ def get_collection_concept_id(collection_record: dict) -> str:
     return collection_record["meta"]["concept-id"]
 
 
-def get_variable_candidates(cmr_base: str, variable_name: str, collection_concept_id: str, edl_token: str) -> list[dict]:
+def get_variable_candidates(cmr_base: str, variable_name: str, collection_concept_id: str, launchpad_token: str) -> list[dict]:
     url = f"{cmr_base}/search/variables.json"
-    headers = {"Authorization": f"Bearer {edl_token}"}
+    headers = {"Authorization": launchpad_token}
     params = {"name": variable_name, "page_size": 2000}
     resp = requests.get(url, headers=headers, params=params)
     resp.raise_for_status()
@@ -93,9 +70,9 @@ def get_variable_candidates(cmr_base: str, variable_name: str, collection_concep
     ]
 
 
-def get_variable_record(cmr_base: str, variable_concept_id: str, edl_token: str) -> dict:
+def get_variable_record(cmr_base: str, variable_concept_id: str, launchpad_token: str) -> dict:
     url = f"{cmr_base}/search/variables.umm_json"
-    headers = {"Authorization": f"Bearer {edl_token}"}
+    headers = {"Authorization": launchpad_token}
     params = {"concept-id": variable_concept_id}
     resp = requests.get(url, headers=headers, params=params)
     resp.raise_for_status()
@@ -217,19 +194,18 @@ def parse_args():
 def main():
     args = parse_args()
 
-    edl_token = get_edl_token(args.env)
     launchpad_token = get_launchpad_token(args.env)
 
     cmr_base = CMR_URLS[args.env]
     provider = args.provider.upper()
 
     print(f"Looking up collection '{args.collection_name}' for provider '{provider}' in {args.env} ({cmr_base})...")
-    collection_record = get_collection_metadata(cmr_base, args.collection_name, provider, edl_token)
+    collection_record = get_collection_metadata(cmr_base, args.collection_name, provider, launchpad_token)
     collection_concept_id = get_collection_concept_id(collection_record)
     print(f"Found collection concept ID: {collection_concept_id}")
 
     print(f"Searching for variable keyword '{args.variable_name}'...")
-    variable_candidates = get_variable_candidates(cmr_base, args.variable_name, collection_concept_id, edl_token)
+    variable_candidates = get_variable_candidates(cmr_base, args.variable_name, collection_concept_id, launchpad_token)
     if not variable_candidates:
         raise ValueError(
             f"No variable found for keyword '{args.variable_name}' linked to collection '{collection_concept_id}' "
@@ -246,7 +222,7 @@ def main():
     variable_concept_id = variable_candidates[0]["concept_id"]
     print(f"Found linked variable concept ID: {variable_concept_id}")
 
-    variable_record = get_variable_record(cmr_base, variable_concept_id, edl_token)
+    variable_record = get_variable_record(cmr_base, variable_concept_id, launchpad_token)
     meta = variable_record["meta"]
     umm = variable_record["umm"]
     native_id = meta["native-id"]

--- a/umm_v_auto/umm_v_update_related_url.py
+++ b/umm_v_auto/umm_v_update_related_url.py
@@ -128,7 +128,6 @@ def update_variable(cmr_base: str, collection_concept_id: str, native_id: str, u
         "Accept": "application/json",
     }
     resp = requests.put(url, data=json.dumps(umm, allow_nan=False), headers=headers)
-    print(resp.json())
     resp.raise_for_status()
     return resp.json()
 


### PR DESCRIPTION
This pull request introduces a new script and comprehensive documentation for updating the `RelatedUrls` field of UMM-V variables in CMR. The script supports adding or deleting related URLs, with options for simple or advanced metadata, and includes robust input validation and environment-specific authentication. The documentation provides detailed usage instructions, recommended practices, and operational notes.

**Major additions and improvements:**

**New script for managing RelatedUrls:**

* Added `umm_v_update_related_url.py`, a script that allows users to add or delete entries in the `RelatedUrls` field of a UMM-V variable in CMR, supporting both simple URL adds and full object adds from a JSON file, as well as deletion by exact URL.
* The script handles authentication via environment variables for both EDL and Launchpad tokens, with clear error handling and fallbacks for different environments.
* Includes logic to deduplicate URLs, validate input files, and ensure only one action (add or delete) is performed per invocation.
* Provides clear user feedback, error messages, and prints the outcome of each operation, including success or failure details from CMR.

**Extensive user documentation:**

* Rewrote the `README.md` to document the new script, including requirements, usage examples, recommended workflows, and operational notes for safely updating UMM-V variable metadata.
* Describes authentication requirements, environment variable usage, and the logic for selecting tokens and CMR environments.
* Details best practices for adding, updating, and deleting RelatedUrls, with example JSON files and command-line invocations.